### PR TITLE
Callback with empty string if no stdout

### DIFF
--- a/lib/linter-chktex.coffee
+++ b/lib/linter-chktex.coffee
@@ -38,6 +38,7 @@ class LinterChktex extends Linter
       splitMessage = message.replace(/\\n/g, "\n")
     else
       # cover case where chktex produces no output on stdout
+      super('', callback)
       return
 
     super(splitMessage, callback)


### PR DESCRIPTION
This fixes the problem where errors don't clear if `chktex` reports no errors.
