### PR TITLE
Activate the plugin also for other LaTeX grammars

### DIFF
--- a/lib/linter-chktex.coffee
+++ b/lib/linter-chktex.coffee
@@ -19,7 +19,7 @@ module.exports =
 
   provideLinter: ->
     provider =
-      grammarScopes: ['text.tex.latex']
+      grammarScopes: ['text.tex.latex', 'text.tex.latex.beamer', 'text.tex.latex.memoir']
       scope: 'file'
       lintOnFly: true
       lint: (textEditor) =>


### PR DESCRIPTION
Hey!

Just a small patch so that the linter starts also for other LaTeX "dialects"
