### PR TITLE
added color to message IDs

### DIFF
--- a/lib/linter-chktex.coffee
+++ b/lib/linter-chktex.coffee
@@ -89,10 +89,10 @@ module.exports =
         colEnd = 0
         colEnd = colStart + parseInt(match.colLength,10) if match.colLength
         message = match.message
-        message = '#' + match.id + '  '.substr(0,2-match.id.length) + message if showId
+        message = '<span style="width: 2em; text-align: center" class="inline-block highlight-warning">' + match.id + '</span> ' + message if showId
         toReturn.push(
           type: match.type,
-          text: message,
+          html: message,
           filePath: match.file,
           range: [[lineStart, colStart], [lineEnd, colEnd]]
         )


### PR DESCRIPTION
I felt that this would make it easier to read the message IDs.

Here is a preview:

![chktex-linter-message-id](https://cloud.githubusercontent.com/assets/12069845/14222402/fda4f660-f835-11e5-9261-19e390aeee73.png)

@tebbi - What do you think?
