### PR TITLE
Fix for chktex line splitting format on Windows

### DIFF
--- a/lib/linter-chktex.coffee
+++ b/lib/linter-chktex.coffee
@@ -57,7 +57,7 @@ module.exports =
         return []
 
   lintFile: (filePath) ->
-    args = [filePath, '-q', '-I0', '-f%f:%l:%c:%d:%k:%n:%m\\n']
+    args = [filePath, '-q', '-I0', '-f%f:%l:%c:%d:%k:%n:%m\\n\\n']
     if chktexArgs
       for x in chktexArgs
         args.push x
@@ -74,7 +74,7 @@ module.exports =
     else
       xcache.set(rawRegex, regex = XRegExp(rawRegex))
     #for line in output.split(/\r?\n/)
-    for line in output.split('\\n')
+    for line in output.split('\\n\\n')
       match = XRegExp.exec(line, regex)
       if match
         # console.log 'file ' + match.file


### PR DESCRIPTION
For #29.

Adding a second `\\n` to the chktex format allows the splitter to distinguish between an end-of-line sequence and a Windows pathname (e.g. "c:\thesis\new_introduction.tex").

It will still break if your directory is named 'n', but that's a much less likely case than starting a file with that letter.

Should continue to be compatible with Unix-style paths.