### PR TITLE
Map "Message" in chktex to "info" in linter

### DIFF
--- a/lib/linter-chktex.coffee
+++ b/lib/linter-chktex.coffee
@@ -93,6 +93,7 @@ module.exports =
         colEnd = colStart + parseInt(match.colLength,10) if match.colLength
         message = match.message
         message = '<span style="width: 2em; text-align: center" class="inline-block highlight-warning">' + match.id + '</span> ' + message if showId
+        match.type = 'info' if match.type is 'Message'
         toReturn.push(
           type: match.type,
           html: message,

--- a/lib/linter-chktex.coffee
+++ b/lib/linter-chktex.coffee
@@ -92,8 +92,9 @@ module.exports =
         colEnd = 0
         colEnd = colStart + parseInt(match.colLength,10) if match.colLength
         message = match.message
-        message = '<span style="width: 2em; text-align: center" class="inline-block highlight-warning">' + match.id + '</span> ' + message if showId
         match.type = 'info' if match.type is 'Message'
+        if showId
+          message = '<span style="width: 2em; text-align: center" class="inline-block highlight-' + match.type.toLowerCase() + '">' + match.id + '</span> ' + message
         toReturn.push(
           type: match.type,
           html: message,


### PR DESCRIPTION
Currently "messages" in chktex generated using `-m` as chktex arguments will show up in linter as an "Error" (same as `-e` arguments in chktext). This is because chktex uses the word "Message" and linter uses the word "info".