### PR TITLE
Update to use atom-linter 2.0 API

### DIFF
--- a/lib/linter-chktex.coffee
+++ b/lib/linter-chktex.coffee
@@ -48,7 +48,7 @@ module.exports =
       name: 'chktex'
       grammarScopes: ['text.tex.latex', 'text.tex.latex.beamer', 'text.tex.latex.memoir', 'text.tex.latex.knitr']
       scope: 'file'
-      lintOnFly: false
+      lintsOnChange: false
       lint: (textEditor) =>
         if fs.existsSync(textEditor.getPath())
           return @lintFile textEditor.getPath()
@@ -91,13 +91,15 @@ module.exports =
         lineEnd = parseInt(match.line,10) - 1 if match.line
         colEnd = 0
         colEnd = colStart + parseInt(match.colLength,10) if match.colLength
-        message = match.message
-        message = '<span style="width: 2em; text-align: center" class="inline-block highlight-warning">' + match.id + '</span> ' + message if showId
-        toReturn.push(
-          type: match.type,
-          html: message,
-          filePath: match.file,
-          range: [[lineStart, colStart], [lineEnd, colEnd]]
-        )
+        message = if showId then 'ID ' + match.id + ': ' + match.message else match.message
+        toReturn.push({
+          severity: match.type.toLowerCase(),
+          location: {
+            file: match.file,
+            position: [[lineStart, colStart], [lineEnd, colEnd]]
+          },
+          description: message,
+          excerpt: message
+        })
       # console.log toReturn
     return toReturn

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
   "providedServices": {
     "linter": {
       "versions": {
-        "1.0.0": "provideLinter"
+        "2.0.0": "provideLinter"
       }
     }
   }


### PR DESCRIPTION
atom-linter 2.3.0 completely removed the 1.0 API that linter-chktex was
dependent on.  This commit updates linter-chktex to provide a linter
compliant with the modern 2.0 API, restoring function, by making the
following changes:

Updated package.json to provide 2.0 linter.

Updated "lintOnFly" to "lintsOnChange" per 2.0 requirements.

Updated returned message structure to comply with 2.0 format.

Removed HTML in message format, since it (sadly) doesn't seem
to be supported anymore.